### PR TITLE
Upgrade release pipeline to use latest checkout action w/ LFS support

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          lfs: 'true'
 
       - name: Log in to the Container registry
         uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9


### PR DESCRIPTION
This PR upgrades our release pipeline to use version 3 of the checkout action and make it resolve any [Git LFS][lfs] reference. So after checking out our repo, the action fetches the files pointed to by the LFS references and replaces the references with the actual files.

At the moment we've only got one reference `data/cls_new.joblib` which caused the bug detailed in #4. So this PR closes #4.


[lfs]: https://git-lfs.github.com/