### PR TITLE
change sim to make it work w/ kitt4sme cloud.

### DIFF
--- a/tests/sim/runner.py
+++ b/tests/sim/runner.py
@@ -28,8 +28,9 @@ def send_welding_machine_entities():
 def run():
     services_running = False
     try:
-        bootstrap()
-        services_running = True
+        # bootstrap()
+        # services_running = True
+        services_running = False
 
         print('>>> sending welding machine entities to Orion...')
         while True:

--- a/tests/util/fiware.py
+++ b/tests/util/fiware.py
@@ -18,7 +18,8 @@ from tests.util.data_process import Preprocessing
 FILEPATH = 'tests/util/Welding_data_new.csv'
 
 TENANT = 'wamtechnik'
-ORION_EXTERNAL_BASE_URL = 'http://localhost:1026'
+# ORION_EXTERNAL_BASE_URL = 'http://localhost:1026'
+ORION_EXTERNAL_BASE_URL = 'http://kitt4sme.collab-cloud.eu/orion'
 QUANTUMLEAP_INTERNAL_BASE_URL = 'http://quantumleap:8668'
 QUANTUMLEAP_EXTERNAL_BASE_URL = 'http://localhost:8668'
 


### PR DESCRIPTION
@souayb I changed the live simulator slightly to make it work with the current kitt4sme cloud setup.

To test SADS (classic) in kitt4sme.collab-cloud.eu

1. check out the `cloud-demo-sim` branch
2. put `tests/util/Welding_data_new.csv` back in place
3. cd `nix`
4. `nix shell`
5. `cd ..`
6. `poetry shell`
7.  `python tests/sim`
8. browse to https://kitt4sme.collab-cloud.eu/sads/
9. have fun w/ sads

Oh please don't forget to kill the simulator (7) when done!!